### PR TITLE
increased allowed generation time in unit tests from 2s to 3s

### DIFF
--- a/pipeline/unittest/output-spec.js
+++ b/pipeline/unittest/output-spec.js
@@ -3,7 +3,7 @@ describe('tng-sdk-descriptorgen output', function() {
 		// wait 2s for descriptors to generate and load
 		browser.get('');
 		element(by.id('submitBtn')).click();
-		browser.driver.sleep(2000);
+		browser.driver.sleep(3000);
 	});
 
 	


### PR DESCRIPTION
to avoid failing CI/CD tests. sometimes the TLS handshake takes surprisingly long...