### PR TITLE
Support for OSM descriptors

### DIFF
--- a/default-descriptors/osm_default_vnfd.yaml
+++ b/default-descriptors/osm_default_vnfd.yaml
@@ -7,7 +7,7 @@ vnfd-catalog:
       short-name: default-vnfd
       vendor: ETSI
       version: 0.9
-      description: "A default NSD with one default VNFDs"
+      description: "A default VNFD with one VDU"
 
       vdu:
         - id: vdu01
@@ -44,5 +44,3 @@ vnfd-catalog:
           
       mgmt-interface:
         cp: mgmt
-          
-      # TODO: support for multiple VDUs? requires internal conn. points, internal-vld, ...

--- a/genOsm.js
+++ b/genOsm.js
@@ -1,0 +1,119 @@
+/* Copyright (c) 2017 5GTANGO and Paderborn University ALL RIGHTS RESERVED. Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Neither the name of 5GTANGO, Paderborn University
+nor the names of its contributors may be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+This work has been performed in the framework of the 5GTANGO project,
+funded by the European Commission under Grant number 761493 through
+the Horizon 2020 and 5G-PPP programmes. The authors would like to
+acknowledge the contributions of their colleagues of the 5GTANGO
+partner consortium (www.5gtango.eu). */
+
+
+// use provided information to copy and generate descriptors based on the default descriptors
+function genOsmDescriptors(defaultNsd, defaultVnfd, uploadedVnfs) {
+    vnfds = generateOsmVnfds(defaultVnfd, uploadedVnfs);
+    nsd = generateOsmNsd(defaultNsd, vnfds);
+
+    return [nsd, vnfds];
+}
+
+
+// generate VNFDs by copying and editing the default VNFD (not for uploaded VNFDs)
+function generateOsmVnfds(defaultVnfd, uploadedVnfs) {
+    var vnfds = [];
+    var numDefaultVnfs = 0;
+    // iterate through VNFs (using .vnf-select, which points to the VNFD of each VNF)
+    $('.vnf-select').each(function(i, obj) {
+        if (obj.value == "default") {
+            vnfds.push(jQuery.extend(true, {}, defaultVnfd));   // deep copy (necessary for nested VNFD fields)
+            var vnfd = vnfds[i]["vnfd-catalog"]["vnfd"][0];
+            vnfd["id"] = "default-vnf" + numDefaultVnfs;
+            vnfd["name"] = "default-vnf" + numDefaultVnfs;
+            vnfd["short-name"] = "default-vnf" + numDefaultVnfs;
+            vnfd["vendor"] = document.getElementById('vendor').value;
+            vnfd["vdu"][0]["image"] = document.getElementById('image' + (i+1)).value;
+            numDefaultVnfs += 1;
+        }
+        else {
+            console.log("VNF " + i + ": Using uploaded VNFD: " + obj.value);
+            vnfds.push(uploadedVnfs[obj.value]);
+        }
+    });
+
+    return vnfds;
+}
+
+
+function generateOsmNsd(defaultNsd, vnfds) {
+    // edit NSD: general info and involved vnfs (since there's only one NSD, no proper copy needed)
+    var nsd = defaultNsd["nsd-catalog"]["nsd"][0];
+    nsd["vendor"] = document.getElementById('vendor').value;
+    nsd["id"] = document.getElementById('name').value;
+    nsd["name"] = document.getElementById('name').value;
+    nsd["description"] = document.getElementById('description').value;
+
+    var numVnfs = vnfds.length;
+    for (i=0; i<numVnfs; i++) {
+        // list involved vnfs
+        if (!nsd["constituent-vnfd"][i])		//create new entry if non-existent
+            nsd["constituent-vnfd"][i] = {};
+        nsd["constituent-vnfd"][i]["member-vnf-index"] = i;
+        nsd["constituent-vnfd"][i]["vnfd-id-ref"] = vnfds[i]["vnfd-catalog"]["vnfd"][0]["id"];
+
+        // create management connection points
+        if (!nsd["vld"][0]["vnfd-connection-point-ref"][i])		//create new entry if non-existent
+            nsd["vld"][0]["vnfd-connection-point-ref"][i] = {};
+        nsd["vld"][0]["vnfd-connection-point-ref"][i]["member-vnf-index-ref"] = i;
+        nsd["vld"][0]["vnfd-connection-point-ref"][i]["vnfd-connection-point-ref"] = "mgmt";
+        nsd["vld"][0]["vnfd-connection-point-ref"][i]["vnfd-id-ref"] = vnfds[i]["vnfd-catalog"]["vnfd"][0]["id"];
+
+        // TODO: connections between VNFs
+        // create corresponding vLinks
+    //     nsd.virtual_links[0].connection_points_reference[i] = "vnf" + i + ":mgmt";		// mgmt
+    //     nsd.virtual_links[1].id = "input-2-vnf0";								// input to 1st vnf
+    //     nsd.virtual_links[1].connection_points_reference[1] = "vnf0:input";
+    //
+    //     if (!nsd.virtual_links[i+2])		//create new entry if non-existent
+    //         nsd.virtual_links[i+2] = {id:"", connectivity_type:"", connection_points_reference:[]};
+    //     nsd.virtual_links[i+2].connectivity_type = "E-Line";
+    //     nsd.virtual_links[i+2].connection_points_reference[0] = "vnf" + i + ":output";
+    //     if (i != numVnfs-1) {
+    //         nsd.virtual_links[i+2].id = "vnf" + i + "-2-vnf" + (i+1);
+    //         nsd.virtual_links[i+2].connection_points_reference[1] = "vnf" + (i+1) + ":input";
+    //     }
+    //     else {
+    //         nsd.virtual_links[i+2].id = "vnf" + i + "-2-output";
+    //         nsd.virtual_links[i+2].connection_points_reference[1] = "output";
+    //     }
+    // }
+    // nsd.virtual_links[0].connection_points_reference[numVnfs] = "mgmt";
+    //
+    // // adjust forwarding graph
+    // nsd.forwarding_graphs[0].number_of_virtual_links = numVnfs + 1;
+    // for (i=1; i<nsd.virtual_links.length; i++)		// skip 1st vLink (mgmt)
+    //     nsd.forwarding_graphs[0].constituent_virtual_links[i-1] = nsd.virtual_links[i].id;
+    // for (i=0; i<numVnfs; i++)
+    //     nsd.forwarding_graphs[0].constituent_vnfs[i] = "vnf" + i;
+    // var pos = 0;
+    // // take in- and output of each vLink
+    // for (i=1; i<nsd.virtual_links.length; i++) {		// skip 1st vLink (mgmt)
+    //     nsd.forwarding_graphs[0].network_forwarding_paths[0].connection_points[pos] = {connection_point_ref: nsd.virtual_links[i].connection_points_reference[0], position: pos+1};
+    //     pos++;
+    //     nsd.forwarding_graphs[0].network_forwarding_paths[0].connection_points[pos] = {connection_point_ref: nsd.virtual_links[i].connection_points_reference[1], position: pos+1};
+    //     pos++;
+    }
+
+    return defaultNsd;
+}

--- a/genOsm.js
+++ b/genOsm.js
@@ -78,41 +78,25 @@ function generateOsmNsd(defaultNsd, vnfds) {
         nsd["vld"][0]["vnfd-connection-point-ref"][i]["member-vnf-index-ref"] = i;
         nsd["vld"][0]["vnfd-connection-point-ref"][i]["vnfd-connection-point-ref"] = "mgmt";
         nsd["vld"][0]["vnfd-connection-point-ref"][i]["vnfd-id-ref"] = vnfds[i]["vnfd-catalog"]["vnfd"][0]["id"];
+    }
 
-        // TODO: connections between VNFs
-        // create corresponding vLinks
-    //     nsd.virtual_links[0].connection_points_reference[i] = "vnf" + i + ":mgmt";		// mgmt
-    //     nsd.virtual_links[1].id = "input-2-vnf0";								// input to 1st vnf
-    //     nsd.virtual_links[1].connection_points_reference[1] = "vnf0:input";
-    //
-    //     if (!nsd.virtual_links[i+2])		//create new entry if non-existent
-    //         nsd.virtual_links[i+2] = {id:"", connectivity_type:"", connection_points_reference:[]};
-    //     nsd.virtual_links[i+2].connectivity_type = "E-Line";
-    //     nsd.virtual_links[i+2].connection_points_reference[0] = "vnf" + i + ":output";
-    //     if (i != numVnfs-1) {
-    //         nsd.virtual_links[i+2].id = "vnf" + i + "-2-vnf" + (i+1);
-    //         nsd.virtual_links[i+2].connection_points_reference[1] = "vnf" + (i+1) + ":input";
-    //     }
-    //     else {
-    //         nsd.virtual_links[i+2].id = "vnf" + i + "-2-output";
-    //         nsd.virtual_links[i+2].connection_points_reference[1] = "output";
-    //     }
-    // }
-    // nsd.virtual_links[0].connection_points_reference[numVnfs] = "mgmt";
-    //
-    // // adjust forwarding graph
-    // nsd.forwarding_graphs[0].number_of_virtual_links = numVnfs + 1;
-    // for (i=1; i<nsd.virtual_links.length; i++)		// skip 1st vLink (mgmt)
-    //     nsd.forwarding_graphs[0].constituent_virtual_links[i-1] = nsd.virtual_links[i].id;
-    // for (i=0; i<numVnfs; i++)
-    //     nsd.forwarding_graphs[0].constituent_vnfs[i] = "vnf" + i;
-    // var pos = 0;
-    // // take in- and output of each vLink
-    // for (i=1; i<nsd.virtual_links.length; i++) {		// skip 1st vLink (mgmt)
-    //     nsd.forwarding_graphs[0].network_forwarding_paths[0].connection_points[pos] = {connection_point_ref: nsd.virtual_links[i].connection_points_reference[0], position: pos+1};
-    //     pos++;
-    //     nsd.forwarding_graphs[0].network_forwarding_paths[0].connection_points[pos] = {connection_point_ref: nsd.virtual_links[i].connection_points_reference[1], position: pos+1};
-    //     pos++;
+     // create vLinks between VNFs
+     for (i=0; i<numVnfs-1; i++) {
+        // start with vld i+1 because vld 0 is the mgmt vld
+        nsd["vld"][i+1] = {};
+        nsd["vld"][i+1]["id"] = "vnf" + i + "-2-vnf" + (i+1);
+        nsd["vld"][i+1]["name"] = "vnf" + i + "-2-vnf" + (i+1);
+        nsd["vld"][i+1]["vnfd-connection-point-ref"] = [];
+        nsd["vld"][i+1]["vnfd-connection-point-ref"][0] = {
+            "member-vnf-index-ref": i,
+            "vnfd-connection-point-ref": "output",
+            "vnfd-id-ref": vnfds[i]["vnfd-catalog"]["vnfd"][0]["id"]
+        };
+        nsd["vld"][i+1]["vnfd-connection-point-ref"][1] = {
+            "member-vnf-index-ref": i+1,
+            "vnfd-connection-point-ref": "input",
+            "vnfd-id-ref": vnfds[i+1]["vnfd-catalog"]["vnfd"][0]["id"]
+        };
     }
 
     return defaultNsd;

--- a/genTango.js
+++ b/genTango.js
@@ -23,15 +23,15 @@ partner consortium (www.5gtango.eu). */
 
 // use provided information to copy and generate descriptors based on the default descriptors
 function genTangoDescriptors(defaultNsd, defaultVnfd, uploadedVnfs) {
-    vnfds = generateVnfds(defaultVnfd, uploadedVnfs);
-    nsd = generateNsd(defaultNsd, vnfds);
+    vnfds = generateTangoVnfds(defaultVnfd, uploadedVnfs);
+    nsd = generateTangoNsd(defaultNsd, vnfds);
 
     return [nsd, vnfds];
 }
 
 
 // generate VNFDs by copying and editing the default VNFD (not for uploaded VNFDs)
-function generateVnfds(defaultVnfd, uploadedVnfs) {
+function generateTangoVnfds(defaultVnfd, uploadedVnfs) {
     var vnfds = [];
     defaultVnfd.author = document.getElementById('author').value;
     defaultVnfd.vendor = document.getElementById('vendor').value;
@@ -55,7 +55,7 @@ function generateVnfds(defaultVnfd, uploadedVnfs) {
 }
 
 
-function generateNsd(defaultNsd, vnfds) {
+function generateTangoNsd(defaultNsd, vnfds) {
     // copy and edit NSD: general info and involved vnfs
     var nsd = defaultNsd;		// since there's only one NSD, no proper copy needed
     nsd.author = document.getElementById('author').value;

--- a/generate.js
+++ b/generate.js
@@ -109,34 +109,30 @@ function loadDescriptors() {
 	document.getElementById('downloadBtn').style.display = 'block';
 
     // load descriptors; only cache default descriptors in production, not in development
-	$.ajax({url: tangoVnfdUrl, success: setVnfd, cache: productionMode});
-	$.ajax({url: tangoNsdUrl, success: setNsd, cache: productionMode});
+	var loadTangoVnfd = $.ajax({url: tangoVnfdUrl, cache: productionMode});
+	var loadTangoNsd = $.ajax({url: tangoNsdUrl, cache: productionMode});
+    var loadOsmVnfd = $.ajax({url: osmVnfdUrl, cache: productionMode});
+    var loadOsmNsd = $.ajax({url: osmNsdUrl, cache: productionMode});
+    $.when(loadTangoVnfd, loadTangoNsd, loadOsmVnfd, loadOsmNsd).then(generateDescriptors);
 	
 	return false;
 }
 
-function setVnfd(data) {
-	defaultTangoVnfd = jsyaml.load(data);
-
-	if (typeof defaultTangoNsd != 'undefined')
-		generateDescriptors();
-}
-
-function setNsd(data) {
-	defaultTangoNsd = jsyaml.load(data);
-	
-	if (typeof defaultTangoVnfd != 'undefined')
-		generateDescriptors();
-}
-
 
 // trigger generation of Tango and OSM descriptors
-function generateDescriptors() {
-    var descriptors = genTangoDescriptors(defaultTangoNsd, defaultTangoVnfd, uploadedVnfs);
-    // TODO: generate OSM descriptors
+function generateDescriptors(data1, data2, data3, data4) {
+    // get the returned default
+    defaultTangoVnfd = jsyaml.safeLoad(data1[0]);
+    defaultTangoNsd = jsyaml.safeLoad(data2[0]);
+    defaultOsmVnfd = jsyaml.safeLoad(data3[0]);
+    defaultOsmNsd = jsyaml.safeLoad(data4[0]);
+
+    //var descriptors = genTangoDescriptors(defaultTangoNsd, defaultTangoVnfd, uploadedVnfs);
+    var descriptors = genOsmDescriptors(defaultOsmNsd, defaultOsmVnfd, uploadedVnfs);
 
     var nsd = descriptors[0];
     var vnfds = descriptors[1];
+
     showDescriptors(nsd, vnfds);
 }
 

--- a/generate.js
+++ b/generate.js
@@ -24,10 +24,14 @@ partner consortium (www.5gtango.eu). */
 // global variables
 var defaultTangoVnfd;
 var defaultTangoNsd;
-var productionMode = true;     // productionMode = true --> load default descriptors faster (default!); = false --> reflect changed descriptors within minutes
 var defaultOsmVnfd;
 var defaultOsmNsd;
+var tangoVnfds;
+var tangoNsd;
+var osmVnfds;
+var osmNsd;
 var uploadedVnfs = {};
+var productionMode = true;     // productionMode = true --> load default descriptors faster (default!); = false --> reflect changed descriptors within minutes
 
 // button click
 $('#submitBtn').click(loadDescriptors);
@@ -127,39 +131,65 @@ function generateDescriptors(data1, data2, data3, data4) {
     defaultOsmVnfd = jsyaml.safeLoad(data3[0]);
     defaultOsmNsd = jsyaml.safeLoad(data4[0]);
 
-    //var descriptors = genTangoDescriptors(defaultTangoNsd, defaultTangoVnfd, uploadedVnfs);
+    var descriptors = genTangoDescriptors(defaultTangoNsd, defaultTangoVnfd, uploadedVnfs);
+    tangoNsd = descriptors[0];
+    tangoVnfds = descriptors[1];
+
     var descriptors = genOsmDescriptors(defaultOsmNsd, defaultOsmVnfd, uploadedVnfs);
+    osmNsd = descriptors[0];
+    osmVnfds = descriptors[1];
 
-    var nsd = descriptors[0];
-    var vnfds = descriptors[1];
-
-    showDescriptors(nsd, vnfds);
+    showDescriptors();
 }
 
 
-// show the edited descriptors for further editing and copying
-function showDescriptors(nsd, vnfds) {	
+// show the generated descriptors for further editing and copying
+function showDescriptors() {
 	// print instructions
 	document.getElementById('info').innerHTML = "Please edit, copy & paste, or download the descriptors below as needed.";
-	
-	// print NSD
-	var nsdHeader = document.getElementById('nsd');
-	nsdHeader.innerHTML = "NSD";
-	var nsdCode = document.getElementById('nsd-code');
-	addCode("nsd", nsd, nsdCode);
-	addDownloadButton("nsd", nsd, nsdCode);
+
+	// TODO: avoid duplicate code by iterating over all supported platforms (currently tango and osm)
+    // Tango
+    document.getElementById('tango').innerHTML = "5GTANGO descriptors";
+    var nsd = tangoNsd;
+    var vnfds = tangoVnfds;
+    // print NSD
+	document.getElementById('tango-nsd').innerHTML = "NSD";
+	var nsdCode = document.getElementById('tango-nsd-code');
+	addCode("tango-nsd", nsd, nsdCode);
+	addDownloadButton("tango-nsd", nsd, nsdCode);
 	
 	// print VNFDs
-	var vnfdHeader = document.getElementById('vnfds');
-	vnfdHeader.innerHTML = "VNFDs";
-	var vnfdCode = document.getElementById('vnfd-code');
-	for (i = 0; i < vnfds.length; i++) {
-		var vnfdSubheader = document.createElement('h3');
+	document.getElementById('tango-vnfds').innerHTML = "VNFDs";
+	var vnfdCode = document.getElementById('tango-vnfd-code');
+	for (var i = 0; i < vnfds.length; i++) {
+		var vnfdSubheader = document.createElement('h4');
 		vnfdSubheader.innerHTML = "VNFD " + i;
 		vnfdCode.appendChild(vnfdSubheader);
-		addCode("vnfd" + i, vnfds[i], vnfdCode);
-		addDownloadButton("vnfd" + i, vnfds[i], vnfdCode);
+		addCode("tango-vnfd" + i, vnfds[i], vnfdCode);
+		addDownloadButton("tango-vnfd" + i, vnfds[i], vnfdCode);
 	}
+
+    // OSM
+    document.getElementById('osm').innerHTML = "OSM descriptors";
+    var nsd = osmNsd;
+    var vnfds = osmVnfds;
+    // print NSD
+    document.getElementById('osm-nsd').innerHTML = "NSD";
+    var nsdCode = document.getElementById('osm-nsd-code');
+    addCode("osm-nsd", nsd, nsdCode);
+    addDownloadButton("osm-nsd", nsd, nsdCode);
+
+    // print VNFDs
+    document.getElementById('osm-vnfds').innerHTML = "VNFDs";
+    var vnfdCode = document.getElementById('osm-vnfd-code');
+    for (var i = 0; i < vnfds.length; i++) {
+        var vnfdSubheader = document.createElement('h4');
+        vnfdSubheader.innerHTML = "VNFD " + i;
+        vnfdCode.appendChild(vnfdSubheader);
+        addCode("osm-vnfd" + i, vnfds[i], vnfdCode);
+        addDownloadButton("osm-vnfd" + i, vnfds[i], vnfdCode);
+    }
 	
 	PR.prettyPrint();
 }

--- a/generate.js
+++ b/generate.js
@@ -238,20 +238,24 @@ function download(data, filename, type = "text/yaml") {
 	}, 0); 
 }
 	
-	
+
+// TODO: download in project format (somehow use the project tool)
 // create and download zip file of all descriptors
 function downloadAll() {
 	var zip = JSZip();
-	
-	// retrieve current descriptors to cover possible manual changes
+
+	// retrieve and zip current descriptors to cover possible manual changes
 	var divNode = document.getElementById('descriptors');
 	var children = divNode.getElementsByTagName('pre');
 	for (i = 0; i < children.length; i++) {
+	    console.log(i);
+	    console.log(children[i]);
 		var code = children[i].innerText;
-		var yaml = jsyaml.load(code);
-		zip.file(yaml.name + ".yaml", code);
+		// TODO: more useful file names
+		zip.file("descriptor" + i + ".yaml", code);
 	}
-	
+
+	// download the zipped files
 	zip.generateAsync({type:"blob"}).then(function(content) {
 		download(content, "descriptors.zip", "blob");
 	});

--- a/index.html
+++ b/index.html
@@ -73,10 +73,16 @@
             </div>
 
             <div id="descriptors" class="form-group">
-                <h2 id="nsd"></h2>
-                <p id="nsd-code"></p>
-                <h2 id="vnfds"></h2>
-                <p id="vnfd-code"></p>
+                <h2 id="tango"></h2>
+                <h3 id="tango-nsd"></h3>
+                <p id="tango-nsd-code"></p>
+                <h3 id="tango-vnfds"></h3>
+                <p id="tango-vnfd-code"></p>
+                <h2 id="osm"></h2>
+                <h3 id="osm-nsd"></h3>
+                <p id="osm-nsd-code"></p>
+                <h3 id="osm-vnfds"></h3>
+                <p id="osm-vnfd-code"></p>
             </div>
 
         </main><!-- /.container -->

--- a/index.html
+++ b/index.html
@@ -97,5 +97,6 @@
         <!--<script src="https://cdn.rawgit.com/enyo/dropzone/e69b9af5/dist/dropzone.js"></script>-->
         <script src="generate.js"></script>
         <script src="genTango.js"></script>
+        <script src="genOsm.js"></script>
     </body>
 </html>

--- a/pipeline/unittest/output-spec.js
+++ b/pipeline/unittest/output-spec.js
@@ -11,8 +11,10 @@ describe('tng-sdk-descriptorgen output', function() {
 	it('should generate and show the descriptors', function() {	
 		expect(element(by.id('info')).getText()).toEqual('Please edit, copy & paste, or download the descriptors below as needed.');
 		var codeBlocks = element.all(by.className('prettyprint lang-yaml'));
-		expect(codeBlocks.first().getAttribute('id')).toEqual('nsdCode');
-		expect(codeBlocks.count()).toEqual(2);		// default: 1 NSD + 1 VNFD
+        // default: 1 NSD + 1 VNFD for each Tango and OSM
+		expect(codeBlocks.first().getAttribute('id')).toEqual('tango-nsdCode');
+        expect(codeBlocks.last().getAttribute('id')).toEqual('osm-vnfd0Code');
+		expect(codeBlocks.count()).toEqual(4);
 	});
 	
 	// non-trivial:


### PR DESCRIPTION
* Now generates both Tango and OSM descriptors based on defined default descriptors
* Allows variable number of VNFs + adjusting high-level info like vendor, service name, VNF image, ...
* Shows both generated descriptors
* Download all: Zips and downloads all generated descriptors, taking into account possible adjustments made in the GUI

Closes #11 